### PR TITLE
Use separate ya-runtime-vm-nvidia package

### DIFF
--- a/create-or-update-local-repository.sh
+++ b/create-or-update-local-repository.sh
@@ -61,6 +61,7 @@ download_deb_files \
     https://github.com/golemfactory/ya-runtime-wasi/releases/download/pre-rel-v0.2.4/ya-runtime-wasi-cli_0.2.3_amd64.deb \
     https://github.com/golemfactory/ya-installer-resources/releases/download/v0.1.12/ya-installer-resources_v0.1.12.deb \
     https://github.com/golemfactory/ya-runtime-vm/releases/download/pre-rel-v0.4.0-ITL-rc12/ya-runtime-vm_pre-rel-v0.4.0-ITL-rc12_amd64.deb \
+    https://github.com/golemfactory/ya-runtime-vm-nvidia/releases/download/pre-rel-v0.1.3-rc3/ya-runtime-vm-nvidia_pre-rel-v0.1.3-rc3.deb \
     https://github.com/fepitre/golem-nvidia-kernel/releases/download/v6.1.58-1/golem-nvidia-kernel_6.1.58-1_amd64.deb
 
 # Add the new .deb files to the local repository and sign the repository metadata

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unattended-upgrades \
     golem-provider \
     golem-nvidia-kernel \
-    ya-runtime-vm \
+    ya-runtime-vm-nvidia \
     ya-runtime-wasi-cli \
     ya-installer-resources && apt-get clean
 
@@ -97,13 +97,6 @@ COPY 20auto-upgrades /etc/apt/apt.conf.d/
 RUN mv /usr/lib/yagna/plugins/ya-runtime-vm/runtime/vmrt \
        /usr/lib/yagna/plugins/ya-runtime-vm/runtime/vmrt.orig
 RUN ln -s /usr/bin/qemu-system-x86_64 /usr/lib/yagna/plugins/ya-runtime-vm/runtime/vmrt
-
-# FIXME: This is temporary until ya-runtime-vm-nvidia gets deb package
-RUN mv /usr/lib/yagna/plugins/ya-runtime-vm/runtime/self-test.gvmi \
-        /usr/lib/yagna/plugins/ya-runtime-vm/runtime/self-test.gvmi.orig
-RUN bash -c "curl -L 'https://github.com/golemfactory/ya-runtime-vm-nvidia/releases/download/pre-rel-v0.1.3-rc1/ya-runtime-vm-nvidia-linux-pre-rel-v0.1.3-rc1.tar.gz' \
-        | tar xzO ya-runtime-vm-nvidia-linux-pre-rel-v0.1.3-rc1/ya-runtime-vm-nvidia/runtime/self-test.gvmi \
-        > /usr/lib/yagna/plugins/ya-runtime-vm/runtime/self-test.gvmi"
 
 # Copy GOLEM Wizard and Systemd service
 COPY golemwz.py /usr/local/bin/golemwz

--- a/rootfs/golemwz.py
+++ b/rootfs/golemwz.py
@@ -338,8 +338,6 @@ def preset_exists(runtime_id):
 
 def configure_runtime(runtime_path, selected_gpu):
     runtime_content = json.loads(runtime_path.read_text())
-    # We rename default vm runtime name as we override its content
-    runtime_content[0]["name"] = "vm-nvidia"
     runtime_gpu_arg = f"--runtime-arg=--pci-device={selected_gpu['slot']}"
     runtime_content[0].setdefault("extra-args", [])
     if runtime_gpu_arg not in runtime_content[0]["extra-args"]:
@@ -835,7 +833,7 @@ def main():
                 shutil.copy2(runtime_json, plugins_dir)
 
         runtime_path = (
-            (Path("~").expanduser() / ".local/lib/yagna/plugins/ya-runtime-vm.json")
+            (Path("~").expanduser() / ".local/lib/yagna/plugins/ya-runtime-vm-nvidia.json")
             .expanduser()
             .resolve()
         )


### PR DESCRIPTION
Do not copy self-test img manually anymore, use proper package. Now the
vm-nvidia runtime is installed into a separate directory.
